### PR TITLE
Revert equation numbering back to standard form

### DIFF
--- a/präambel/package.tex
+++ b/präambel/package.tex
@@ -85,7 +85,6 @@
 
 \renewcommand{\thefigure}{Abb. \arabic{chapter}.\arabic{figure}} 
 \renewcommand{\thetable}{Tab. \arabic{chapter}.\arabic{table}}
-\renewcommand{\theequation}{Gl. \arabic{equation}}
 \renewcommand*{\figureformat}{\thefigure} 
 \renewcommand*{\tableformat}{\thetable} 
 \renewcommand*{\captionformat}{: }  


### PR DESCRIPTION
Standard form of section-wise equation numbering appears to be more useful for common cases than continuous number with "Gl.".